### PR TITLE
Add Gracile meta-framework + starters

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,9 +206,9 @@ At Lit's core is a boilerplate-killing component base class that provides reacti
 
 ## Meta Frameworks
 
-## Tools
-
 - [Gracile](https://gracile.js.org/) - Thin, full-stack meta-framework. Powered by Vite and Lit SSR.
+
+## Tools
 
 ### Building
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ At Lit's core is a boilerplate-killing component base class that provides reacti
 - [Design Systems](#design-systems)
 - [Component Libraries](#component-libraries)
 - [Standalone Components](#standalone-components)
+- [Meta Frameworks](#meta-frameworks)
 - [Tools](#tools)
   - [Building](#building)
   - [Linting](#linting)
@@ -58,6 +59,7 @@ At Lit's core is a boilerplate-killing component base class that provides reacti
 
 ## Starter Templates
 
+- [Gracile Starters](https://github.com/gracile-web/starter-projects) - Gracile full-stack starter projects (SSR/SSG).
 - [LitElement JavaScript starter](https://github.com/lit/lit-element-starter-js) - Sample component using LitElement with JavaScript.
 - [LitElement TypeScript starter](https://github.com/lit/lit-element-starter-ts) - Sample component using LitElement with TypeScript.
 - [hello-web-components](https://github.com/fernandopasik/hello-web-components) - Simple starter web component written in TypeScript using Lit.
@@ -202,7 +204,11 @@ At Lit's core is a boilerplate-killing component base class that provides reacti
 - [`<round-slider>`](https://github.com/thomasloven/round-slider) - Simple round slider web component built with Lit.
 - [`<stl-part-viewer>`](https://github.com/justinribeiro/stl-part-viewer) - LitElement web component that utilizes Three.js to display an STL model file.
 
+## Meta Frameworks
+
 ## Tools
+
+- [Gracile](https://gracile.js.org/) - Thin, full-stack meta-framework. Powered by Vite and Lit SSR.
 
 ### Building
 


### PR DESCRIPTION
Hi there,

I'm purposing to add Gracile which is built with Vite, Lit SSR, and have a platform oriented philosophy.

I wasn't quite sure about adding a category, since there isn't other full-stack framework out there built exclusively with Lit SSR (paired with a bundler), yet. Tell me if it's OK for you, or if I should move it elsewhere.

Thank you :)