### PR TITLE
Add lit-image-cropper to Standalone Components category

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ At Lit's core is a boilerplate-killing component base class that provides reacti
 - [`<rapi-doc>`](https://github.com/mrin9/RapiDoc) - Web Component to view OpenAPI 3.0 & Swagger 2.0 Spec.
 - [`<round-slider>`](https://github.com/thomasloven/round-slider) - Simple round slider web component built with Lit.
 - [`<stl-part-viewer>`](https://github.com/justinribeiro/stl-part-viewer) - LitElement web component that utilizes Three.js to display an STL model file.
+- [`<lit-image-cropper>`](https://github.com/andy-austin/lit-image-cropper) - Fast and lightweight image cropper component.
 
 ## Tools
 

--- a/README.md
+++ b/README.md
@@ -196,12 +196,12 @@ At Lit's core is a boilerplate-killing component base class that provides reacti
 - [`<json-viewer>`](https://github.com/alenaksu/json-viewer) - Web Component to visualize JSON data in a tree view.
 - [`<light-gallery>`](https://github.com/sachinchoolur/lightGallery/tree/master/lightgallery-lit) - Full featured JavaScript image and video gallery for Lit.
 - [`<lit-datatable>`](https://github.com/DoubleTrade/lit-datatable) - Material Design implementation of a data table, powered by LitElement.
+- [`<lit-image-cropper>`](https://github.com/andy-austin/lit-image-cropper) - Fast and lightweight image cropper component.
 - [`<lottie-player>`](https://github.com/LottieFiles/lottie-player) - Web Component for easily embedding and playing Lottie animations.
 - [`<model-viewer>`](https://github.com/GoogleWebComponents/model-viewer) - A web component for rendering interactive 3D models.
 - [`<rapi-doc>`](https://github.com/mrin9/RapiDoc) - Web Component to view OpenAPI 3.0 & Swagger 2.0 Spec.
 - [`<round-slider>`](https://github.com/thomasloven/round-slider) - Simple round slider web component built with Lit.
 - [`<stl-part-viewer>`](https://github.com/justinribeiro/stl-part-viewer) - LitElement web component that utilizes Three.js to display an STL model file.
-- [`<lit-image-cropper>`](https://github.com/andy-austin/lit-image-cropper) - Fast and lightweight image cropper component.
 
 ## Tools
 


### PR DESCRIPTION
This PR adds [`<lit-image-cropper>`](https://github.com/andy-austin/lit-image-cropper) to the list.

`<lit-image-cropper>` is a fast and lightweight image cropper web component built with Lit. It’s perfect for web applications that need a simple image editing tool that’s easy to integrate.

The component adheres to modern web standards and provides a smooth user experience for cropping images, with flexibility to fit a range of use cases.

See a live demo [here](https://lit-image-cropper.vercel.app/) and the npm package [here](https://www.npmjs.com/package/lit-image-cropper).